### PR TITLE
fix: development workflow

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,10 +3,18 @@ import tailwind from "@astrojs/tailwind";
 
 import preact from "@astrojs/preact";
 
+const isProd = import.meta.env.PROD;
+
+let baseURL = "/";
+
+if (isProd) {
+  baseURL = "/CVTalk";
+}
+
 // https://astro.build/config
 export default defineConfig({
   integrations: [tailwind(), preact()],
-  base: "/CVTalk",
+  base: baseURL,
   build: {
     assets: "resources",
   },

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,9 +1,17 @@
 ---
 import Button from "./Button.astro";
+
+const isProd = import.meta.env.PROD;
+
+let baseURL = "/";
+
+if (isProd) {
+  baseURL = "/CVTalk/";
+}
 ---
 
 <nav class="flex justify-center gap-6 m-4 p-2">
-  <Button href="/CVTalk/#" className="hidden sm:flex">Home</Button>
-  <Button href="/CVTalk/start">Get Started</Button>
-  <Button href="/CVTalk/involved">Get Involved</Button>
+  <Button href={`${baseURL}`} className="hidden sm:flex">Home</Button>
+  <Button href={`${baseURL}start`}>Get Started</Button>
+  <Button href={`${baseURL}involved`}>Get Involved</Button>
 </nav>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,12 +23,10 @@ import { ViewTransitions } from "astro:transitions";
         font-style: normal;
         font-weight: 400;
         src:
-          url(https://obs-chat.christianvillegas.com/assets/fonts/inter-latin-variable-wghtOnly-normal.woff2)
+          url(/assets/fonts/inter-latin-variable-wghtOnly-normal.woff2)
             format("woff2-variations"),
-          url(https://obs-chat.christianvillegas.com/assets/fonts/inter-latin-400-normal.woff2)
-            format("woff2"),
-          url(https://obs-chat.christianvillegas.com/assets/fonts/inter-latin-400-normal.woff)
-            format("woff");
+          url(/assets/fonts/inter-latin-400-normal.woff2) format("woff2"),
+          url(/assets/fonts/inter-latin-400-normal.woff) format("woff");
         unicode-range: u+00??, u+0131, u+0152-0153, u+02bb-02bc, u+02c6, u+02da,
           u+02dc, u+2000-206f, u+2074, u+20ac, u+2122, u+2191, u+2193, u+2212,
           u+2215, u+feff, u+fffd;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,14 @@
 import Layout from "../layouts/Layout.astro";
 import Title from "../components/Title.astro";
 import Button from "../components/Button.astro";
+
+const isProd = import.meta.env.PROD;
+
+let baseURL = "/";
+
+if (isProd) {
+  baseURL = "/CVTalk/";
+}
 ---
 
 <Layout>
@@ -17,7 +25,7 @@ import Button from "../components/Button.astro";
     </p>
   </article>
   <Button
-    href="/CVTalk/start"
+    href={`${baseURL}start`}
     className="my-20 mx-auto bg-orange-500 py-3 px-6 text-lg font-bold"
   >
     Get started


### PR DESCRIPTION
Debido a que la configuración de la propiedad `base` de la configuración Astro toma por defecto la carpeta de despliegue para GitHub Pages `/CVTalk`, eso hace un poco incómodo el flujo de desarrollo.

Al ejecutar el comando de desarrollo se muestra por defecto una vista 404.

![Screenshot 2023-09-23 113031](https://github.com/chrisvdev/CVTalk/assets/38303370/c54952ce-42f5-4a40-8bcb-ca75865165ca)

En [066e7a1](https://github.com/chrisvdev/CVTalk/commit/066e7a118429f8fcf5465a54c2da942aa4fa3344), se modificó el archivo de configuración de Astro para que establezca la URL base a `/CVTalk` si es producción, de lo contrario deje la ruta raíz.

Al ejecutar el servidor de desarrollo:

https://github.com/chrisvdev/CVTalk/assets/38303370/b9b805b0-5777-4ead-83ac-1659fa802006

También se corrigieron las URL del menú de navegación en [05f7428](https://github.com/chrisvdev/CVTalk/commit/05f7428b62e60423f453f7d4d89b666ae7120881).

Otro cambio: Se corrigió la ruta de carga de las fuentes.